### PR TITLE
Use decorator

### DIFF
--- a/src/main/eo/org/eolang/hamcrest/assert-that.eo
+++ b/src/main/eo/org/eolang/hamcrest/assert-that.eo
@@ -245,12 +245,7 @@
   # including its mismatch description.
   [matcher format args...] > described-as
 
-    [a] > match
-      matcher.match a > @
-
-    [] > describe-mismatch
-      describe-mismatch. > @
-        matcher
+    matcher > @
 
     [] > description-of
       sprintf > @

--- a/src/main/eo/org/eolang/hamcrest/assert-that.eo
+++ b/src/main/eo/org/eolang/hamcrest/assert-that.eo
@@ -220,12 +220,7 @@
   # but allowing tests to be slightly more expressive.
   [matcher] > is
 
-    [a] > match
-      matcher.match a > @
-
-    [] > describe-mismatch
-      describe-mismatch. > @
-        matcher
+    matcher > @
 
     [] > description-of
       sprintf > @


### PR DESCRIPTION
Closes #58 

Now `.is` and `described-as` uses decorator. Please note that with this two commits I added newline at EOF. If it is not welcome, I can remove it.
