### PR TITLE
added tests with switch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>eo-hamcrest</name>
   <properties>
-    <eolang.version>0.29.1</eolang.version>
+    <eolang.version>0.29.3</eolang.version>
   </properties>
   <description>Hamcrest matchers for EOLANG</description>
   <url>https://github.com/objectionary/eo-hamcrest</url>

--- a/src/main/eo/org/eolang/hamcrest/matchers/close-to-matcher.eo
+++ b/src/main/eo/org/eolang/hamcrest/matchers/close-to-matcher.eo
@@ -32,16 +32,37 @@
 [operand err] > close-to-matcher
 
   memory 0 > mismatch
+  memory 0 > error-template
+  "<%s> differed by <%.4s> more than delta <%s>" > float-errror-message
+  "types was missmatched" > wrong-type-error-message
 
   [a] > match
-    seq > @
-      mismatch.write actual-delta
-      actual-delta.lte 0.0
+    if. > @
+      and.
+        is-float.
+          number operand
+        is-float.
+          number a
+        is-float.
+          number err
+      seq
+        mismatch.write actual-delta
+        actual-delta.lte 0.0
+      seq
+        error-template.write wrong-type-error-message
+        FALSE
+
     [] > actual-delta
       minus. > @
-        abs.
-          number (a.minus operand)
+        float-abs
+          a.minus operand
         err
+
+    [value] > float-abs
+      if. > @
+        value.gte 0.0
+        value
+        value.neg
 
   [act] > describe-mismatch
     sprintf > @
@@ -52,6 +73,6 @@
 
   [] > description-of
     sprintf > @
-      "a numeric value within <%s> of <%s>"
+      "a float value within <%s> of <%s>"
       operand
       err

--- a/src/main/eo/org/eolang/hamcrest/matchers/close-to-matcher.eo
+++ b/src/main/eo/org/eolang/hamcrest/matchers/close-to-matcher.eo
@@ -32,9 +32,6 @@
 [operand err] > close-to-matcher
 
   memory 0 > mismatch
-  memory 0 > error-template
-  "<%s> differed by <%.4s> more than delta <%s>" > float-errror-message
-  "types was missmatched" > wrong-type-error-message
 
   [a] > match
     if. > @
@@ -49,8 +46,7 @@
         mismatch.write actual-delta
         actual-delta.lte 0.0
       seq
-        error-template.write wrong-type-error-message
-        FALSE
+        error "some of the given arguments are not floats"
 
     [] > actual-delta
       minus. > @

--- a/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
@@ -50,3 +50,16 @@
     $.close-to
       1.0
       0.1
+
+[] > slow-test-with-switch
+  assert-that > @
+    switch
+      *
+        TRUE
+        switch
+          *
+            TRUE
+            1.0
+    $.close-to
+      1.0
+      0.1

--- a/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
@@ -40,3 +40,13 @@
   assert-that > @
     -123456789.123456
     $.close-to -123456789.0 0.2
+
+[] > check-switch-close-1
+  assert-that > @
+    switch
+      *
+        TRUE
+        1.0
+    $.close-to
+      1.0
+      0.1

--- a/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
@@ -63,3 +63,19 @@
     $.close-to
       1.0
       0.1
+
+[] > switch-in-switch-in-switch-close-to
+  assert-that > @
+    switch
+      *
+        TRUE
+        switch
+          *
+            TRUE
+            switch
+              *
+                TRUE
+                1.0
+    $.close-to
+      1.0
+      0.1

--- a/src/test/eo/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -64,4 +64,4 @@
       "all of conditions"
   assert-that > @
     suggestion
-    $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a numeric value within <20.0> of <2.2>\n     but: a value was <42.0>"
+    $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a float value within <20.0> of <2.2>\n     but: a value was <42.0>"

--- a/src/test/eo/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -33,7 +33,7 @@
       $.close-to 2.5 0.4
   assert-that > @
     suggestion
-    $.equal-to "\nExpected: a numeric value within <2.5> of <0.4>\n     but: <3.0> differed by <0.09> more than delta <0.4>"
+    $.equal-to "\nExpected: a float value within <2.5> of <0.4>\n     but: <3.0> differed by <0.09> more than delta <0.4>"
 
 [] > zero-is-close-to-float-with-delta-test-failed-output
   [] > suggestion
@@ -42,7 +42,7 @@
       $.close-to 0.5 0.4
   assert-that > @
     suggestion
-    $.equal-to "\nExpected: a numeric value within <0.5> of <0.4>\n     but: <0.0> differed by <0.09> more than delta <0.4>"
+    $.equal-to "\nExpected: a float value within <0.5> of <0.4>\n     but: <0.0> differed by <0.09> more than delta <0.4>"
 
 [] > neg-float-is-close-to-neg-float-with-delta-test-failed-output
   [] > suggestion
@@ -51,4 +51,4 @@
       $.close-to -123456788.0 0.2
   assert-that > @
     suggestion
-    $.equal-to "\nExpected: a numeric value within <-1.23456788E8> of <0.2>\n     but: <-1.23456789123456E8> differed by <0.92> more than delta <0.2>"
+    $.equal-to "\nExpected: a float value within <-1.23456788E8> of <0.2>\n     but: <-1.23456789123456E8> differed by <0.92> more than delta <0.2>"


### PR DESCRIPTION
Closes: #172

What's done:
- added test with `switch` and `close-to` matcher
- redo `close-to` matcher by adding check for float number and remove unnecessary checks from `number.abs` object
- added slow test from original issue

Looks like now `switch` with `close-to` matcher works faster.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `eo-hamcrest` package and improves the `close-to` matcher to specifically handle floating point numbers.

### Detailed summary
- Updated `eo-hamcrest` package to version `0.29.3`
- Improved `close-to` matcher to handle floating point numbers
- Added tests and failed output messages for the new `close-to` matcher
- Other minor improvements in test files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->