### PR TITLE
Replaced test meta from +junit to +tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a collection of test matchers for [EO](https://www.eolang.org) in [Hamcr
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > my-first-test
   assert-that > @
@@ -43,7 +43,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > core-matchers-test
   assert-that > @
@@ -63,7 +63,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > logical-matchers-test
   assert-that > @
@@ -90,7 +90,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > collections-test
   assert-that > @
@@ -105,7 +105,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > collections-test
   assert-that > @
@@ -121,7 +121,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > numbers-matchers-test
   assert-that > @
@@ -142,7 +142,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > text-matchers-test
   assert-that > @
@@ -171,7 +171,7 @@ You can also implement your own matcher by passing parameter to the ```assert-th
 ```
 +package org.eolang
 +alias org.eolang.hamcrest.assert-that
-+junit
++tests
 
 [] > my-custom-matcher-test
   assert-that > @

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>eo-hamcrest</name>
   <properties>
-    <eolang.version>0.29.3</eolang.version>
+    <eolang.version>0.29.4</eolang.version>
   </properties>
   <description>Hamcrest matchers for EOLANG</description>
   <url>https://github.com/objectionary/eo-hamcrest</url>

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,10 @@
   "extends": [
     "config:base"
   ],
-  "ignoreDeps": ["maven-compiler-plugin"]
+  "packageRules": [
+    {
+      "matchPackageNames": ["maven-compiler-plugin"],
+      "allowedVersions": "3.8.1"
+    }
+  ]
 }

--- a/src/test/eo/org/eolang/hamcrest/all-of-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/all-of-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 # @todo #167:45min To add more tests with a new

--- a/src/test/eo/org/eolang/hamcrest/any-of-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/any-of-tests.eo
@@ -23,7 +23,7 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
++tests
 +package org.eolang.hamcrest
 +version 0.0.0
 

--- a/src/test/eo/org/eolang/hamcrest/anything-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/anything-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > anything-two-sum-test

--- a/src/test/eo/org/eolang/hamcrest/arrays-matchers-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/arrays-matchers-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > has-item-int-test

--- a/src/test/eo/org/eolang/hamcrest/blank-string-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/blank-string-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > simple-blank-string

--- a/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/close-to-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > float-is-close-to-float-with-delta-test

--- a/src/test/eo/org/eolang/hamcrest/contains-string-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/contains-string-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > simple-contains-string

--- a/src/test/eo/org/eolang/hamcrest/described-as-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/described-as-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > two-sum-described-as-equal-to-test

--- a/src/test/eo/org/eolang/hamcrest/empty-string-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/empty-string-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > simple-empty-string

--- a/src/test/eo/org/eolang/hamcrest/equal-to-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/equal-to-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.hamcrest.assert-twice-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > two-sum-test

--- a/src/test/eo/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 # @todo #167:45min To add more tests with a new

--- a/src/test/eo/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > any-of-number-test-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/anything-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/anything-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > anything-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > arrays-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > simple-blank-string-failed

--- a/src/test/eo/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > float-is-close-to-float-with-delta-test-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > simple-contains-string-failed

--- a/src/test/eo/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > two-sum-described-as-equal-to-test-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > simple-empty-string-failed

--- a/src/test/eo/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.hamcrest.assert-twice-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > delayed-calculation

--- a/src/test/eo/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > greater-than-int-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/is-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/is-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > is-failed-output-with-two-bools

--- a/src/test/eo/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > simple-contains-string-failed

--- a/src/test/eo/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > less-than-int-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > matches-regex-failed-output

--- a/src/test/eo/org/eolang/hamcrest/failed-output/not-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/not-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > not-failed-output-two-strings

--- a/src/test/eo/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > simple-ends-with-string-failed

--- a/src/test/eo/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/src/test/eo/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.0.0
 
 [] > simple-starts-with-string-failed

--- a/src/test/eo/org/eolang/hamcrest/greater-than-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/greater-than-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > two-sum-greater-than-value-test

--- a/src/test/eo/org/eolang/hamcrest/is-substring-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/is-substring-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > simple-is-substring

--- a/src/test/eo/org/eolang/hamcrest/is-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/is-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > is-two-sum-test

--- a/src/test/eo/org/eolang/hamcrest/less-than-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/less-than-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > two-sum-less-than-value-test

--- a/src/test/eo/org/eolang/hamcrest/matches-regex-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/matches-regex-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > matches-regex-alphabetical-test

--- a/src/test/eo/org/eolang/hamcrest/not-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/not-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > not-equal-two-sum-test

--- a/src/test/eo/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > simple-ends-with-string

--- a/src/test/eo/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/src/test/eo/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.0.0
 
 [] > simple-starts-with-string


### PR DESCRIPTION
Closes: #196

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds tests and updates dependencies for the `eo-hamcrest` library. 

### Detailed summary
- Adds tests for various matchers
- Updates `eolang` dependency from version `0.29.3` to `0.29.4`
- Adds a `packageRules` section to `renovate.json`, allowing only version `3.8.1` of `maven-compiler-plugin`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->