### PR TITLE
avoid pre-releases

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -12,6 +12,7 @@ merge:
   script: |
     mvn clean install -Pqulice --errors -Dstyle.color=never
 release:
+  pre: false
   script: |-
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}" -Dstyle.color=never


### PR DESCRIPTION
#205

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a pre-release check to the release script and updating the Maven version during release. 

### Detailed summary
- Added a `pre` field to the release script to disable pre-release checks.
- Updated the Maven version to the value provided in the `tag` variable during release.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->