### PR TITLE
update gh-pages to `0.5.0`

### DIFF
--- a/objectionary/objects/org/eolang/hamcrest/assert-that.eo
+++ b/objectionary/objects/org/eolang/hamcrest/assert-that.eo
@@ -44,8 +44,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Main object for assertions
 [actual matcher reasons...] > assert-that

--- a/objectionary/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objectionary/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -43,8 +43,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # @todo #167:45min Make this object decorates
 #  another one (let's call it assert). Which will

--- a/objectionary/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Calculates the logical conjunction of multiple matchers.
 # Evaluation is shortcut, so subsequent matchers are not called

--- a/objectionary/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Calculates the logical disjunction of multiple matchers.
 # Evaluation is shortcut, so subsequent matchers are not called

--- a/objectionary/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # A matcher that always returns true.
 [] > anything-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Matcher for array whose elements satisfy a sequence of matchers.
 # The array size must equal the number of element matchers.
@@ -45,7 +45,7 @@
           list
             act
           TRUE
-          [acc i el]
+          [acc el i]
             and. > @
               acc
               if.

--- a/objectionary/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Tests if the examined string contains zero or more whitespace characters and nothing else.
 [] > blank-string-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Compare object that matches when an examined float
 # is equal to the specified operand, within a range of +/- error.

--- a/objectionary/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Matcher that matches if the examined string contains the specified string anywhere.
 [str] > contains-string-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Wraps an existing matcher, overriding its description with that specified.
 # All other functions are delegated to the decorated matcher,

--- a/objectionary/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Tests if the examined string contains zero characters and nothing else.
 [] > empty-string-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Is the value equal to another value
 [x] > equal-to-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Compare object that matches when the examined object
 # is greater than the specified value

--- a/objectionary/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Wraps an existing matcher and apply it to every item in array.
 [matcher] > has-item-matcher
@@ -48,7 +48,7 @@
         list
           a
         FALSE
-        [acc i x]
+        [acc x i]
           or. > @
             acc
             apply x

--- a/objectionary/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Wraps an array of matchers and apply them to every item in array.
 [matchers...] > has-items-matcher
@@ -57,7 +57,7 @@
         list
           act
         FALSE
-        [acc i el]
+        [acc el i]
           or. > @
             acc
             all-match el

--- a/objectionary/objects/org/eolang/hamcrest/matchers/is-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/is-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Decorates another Matcher, retaining the behaviour
 # but allowing tests to be slightly more expressive.

--- a/objectionary/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Tests if the argument is a substring of the actual string.
 [str] > is-substring-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Compare object that matches when the examined object
 # is less than the specified value

--- a/objectionary/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Checks if given string can be generated
 # by the regular expression.

--- a/objectionary/objects/org/eolang/hamcrest/matchers/not-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/not-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Calculates the logical negation of a matcher
 [matcher] > not-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Tests if the argument is a string that ends with a specific substring.
 [str] > string-ends-with-matcher

--- a/objectionary/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
+++ b/objectionary/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.4.0
-+version 0.4.0
++rt jvm org.eolang:eo-hamcrest:0.5.0
++version 0.5.0
 
 # Tests if the argument is a string that starts with a specific substring.
 [str] > string-starts-with-matcher

--- a/objectionary/tests/org/eolang/hamcrest/all-of-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/all-of-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 # @todo #167:45min To add more tests with a new
 #  assert-twice-that object to make sure it

--- a/objectionary/tests/org/eolang/hamcrest/any-of-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/any-of-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +tests
 +package org.eolang.hamcrest
-+version 0.4.0
++version 0.5.0
 
 [] > any-of-numbers-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/anything-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/anything-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > anything-two-sum-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
@@ -25,8 +25,16 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
+# @todo #212:30min Enable the tests when eo-collections 0.10.0 is in objectionary. Need to enable
+#  next tests that were disabled because of conflict with eo-collections 0.10.0:
+#  has-items-int-test, contains-all-of-string-failed, contains-any-of-string-failed,
+#  starts-with-any-of-string-failed, all-of-close-to-failed-output,
+#  any-of-number-test-failed-output, all-of-several-failed-output, starts-with-all-of-string-failed,
+#  ends-with-all-of-string-failed, all-of-number-test-failed-output, ends-with-any-of-string-failed,
+#  arrays-failed-output, any-of-several-failed-output, nested-has-items, arrays-each-items,
+#  arrays-each-items-complex-case, has-item-string-test, has-item-float-test
 [] > has-item-int-test
   assert-that > @
     * 1 2 3
@@ -34,42 +42,48 @@
       $.equal-to 2
 
 [] > has-item-string-test
-  assert-that > @
+  assert-that > res
     * "1" "2" "3"
     $.has-item
       $.equal-to "3"
+  nop > @
 
 [] > has-item-float-test
-  assert-that > @
+  assert-that > res
     * 1.0 44.0
     $.has-item
       $.is
         $.greater-than 10.0
+  nop > @
 
 [] > has-items-int-test
-  assert-that > @
+  assert-that > res
     * 99 101
     $.has-items
       $.greater-than 100
+  nop > @
 
 [] > nested-has-items
-  assert-that > @
+  assert-that > res
     * "a" "b" "c" "d"
     $.has-items
       $.equal-to "c"
+  nop > @
 
 [] > arrays-each-items
-  assert-that > @
+  assert-that > res
     * 1 2
     $.array-each
       $.equal-to 1
       $.equal-to 2
+  nop > @
 
 [] > arrays-each-items-complex-case
-  assert-that > @
+  assert-that > res
     * "vice" "c" -5 ((number 13).as-float)
     $.array-each
       $.equal-to "vice"
       $.equal-to "c"
       $.less-than 0
       $.greater-than 10.0
+  nop > @

--- a/objectionary/tests/org/eolang/hamcrest/blank-string-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/blank-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-blank-string
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/close-to-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/close-to-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > float-is-close-to-float-with-delta-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-contains-string
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/described-as-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/described-as-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > two-sum-described-as-equal-to-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/empty-string-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/empty-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-empty-string
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/equal-to-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/equal-to-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > two-sum-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 # @todo #167:45min To add more tests with a new
 #  assert-twice-that object to make sure failed output messages
@@ -38,9 +38,10 @@
       $.all-of
         $.equal-to 1
       "all of numbers conditions"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "all of numbers conditions\nExpected: <1> equal to value\n     but: a value was <100>"
+  nop > @
 
 [] > all-of-several-failed-output
   [] > suggestion
@@ -51,9 +52,10 @@
         $.greater-than 100
         $.less-than 2
       "all of conditions"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "all of conditions\nExpected: <1> equal to value and <100> less than value and <2> greater than value\n     but: a value was <3>"
+  nop > @
 
 [] > all-of-close-to-failed-output
   [] > suggestion
@@ -66,6 +68,7 @@
         $.greater-than 100.0
         $.close-to 20.0 2.2
       "all of conditions"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a float value within <20.0> of <2.2>\n     but: a value was <42.0>"
+  nop > @

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > any-of-number-test-failed-output
   [] > suggestion
@@ -33,9 +33,10 @@
       150.minus 50
       $.any-of
         $.equal-to 1
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "\nExpected: <1> equal to value\n     but: a value was <100>"
+  nop > @
 
 [] > any-of-several-failed-output
   [] > suggestion
@@ -45,9 +46,10 @@
         $.equal-to 1
         $.greater-than 100
         $.less-than -6
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "\nExpected: <1> equal to value or <100> less than value or <-6> greater than value\n     but: a value was <3>"
+  nop > @
 
 # @todo #149:30min To remove this nop object
 #  when this test will be stable. To do that we

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > anything-failed-output
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > arrays-failed-output
   [] > suggestion
@@ -33,6 +33,7 @@
       $.array-each
         $.equal-to 1
         $.equal-to 3
-  assert-that > @
+  assert-that > res
     suggestion
     $.contains-string "\nExpected: <1> equal to value and <3> equal to value\n     but: mismatches:"
+  nop > @

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-blank-string-failed
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > float-is-close-to-float-with-delta-test-failed-output
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-contains-string-failed
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > two-sum-described-as-equal-to-test-failed-output
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-empty-string-failed
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > delayed-calculation
   memory 0 > m

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > greater-than-int-failed-output
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > is-failed-output-with-two-bools
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-contains-string-failed
   [] > suggestion
@@ -43,9 +43,10 @@
       $.any-of
         $.is-substring "2"
       "is-substring"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "is-substring\nExpected: string contains: <2>\n     but: a value was <Hello>"
+  nop > @
 
 [] > contains-all-of-string-failed
   [] > suggestion
@@ -55,9 +56,10 @@
         $.is-substring "2"
         $.is-substring "happy"
       "is-substring"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "is-substring\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+  nop > @
 
 
 

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > less-than-int-failed-output
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > matches-regex-failed-output
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > not-failed-output-two-strings
   [] > suggestion

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-ends-with-string-failed
   [] > suggestion
@@ -45,9 +45,10 @@
         $.contains-string "世"
         $.string-ends-with "ет"
       "ends-with"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "ends-with\nExpected: string contains: <Привет> and string contains: <世> and string ends with: <ет>\n     but: a value was <Привет, 世界>"
+  nop > @
 
 [] > ends-with-all-of-string-failed
   [] > suggestion
@@ -58,10 +59,7 @@
         $.string-ends-with "dddd"
         $.contains-string "界"
       "ends-with"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "ends-with\nExpected: string contains: <Привет> or string ends with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
-
-
-
-
+  nop > @

--- a/objectionary/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/objectionary/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-starts-with-string-failed
   [] > suggestion
@@ -45,9 +45,10 @@
         $.contains-string "世"
         $.string-starts-with "ет"
       "starts-with"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "starts-with\nExpected: string contains: <Привет> and string contains: <世> and string starts with: <ет>\n     but: a value was <Привет, 世界>"
+  nop > @
 
 [] > starts-with-all-of-string-failed
   [] > suggestion
@@ -58,10 +59,7 @@
         $.string-starts-with "dddd"
         $.contains-string "界"
       "starts-with"
-  assert-that > @
+  assert-that > res
     suggestion
     $.equal-to "starts-with\nExpected: string contains: <Привет> or string starts with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
-
-
-
-
+  nop > @

--- a/objectionary/tests/org/eolang/hamcrest/greater-than-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/greater-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > two-sum-greater-than-value-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-is-substring
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/is-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/is-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > is-two-sum-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/less-than-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/less-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > two-sum-less-than-value-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/matches-regex-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/matches-regex-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > matches-regex-alphabetical-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/not-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/not-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > not-equal-two-sum-test
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-ends-with-string
   assert-that > @

--- a/objectionary/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/objectionary/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.4.0
++version 0.5.0
 
 [] > simple-starts-with-string
   assert-that > @


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version of the `org.eolang.hamcrest` package and its tests from 0.4.0 to 0.5.0.

### Detailed summary
- Updated version of `org.eolang.hamcrest` package and its tests from 0.4.0 to 0.5.0.

> The following files were skipped due to too many changes: `objectionary/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo`, `objectionary/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo`, `objectionary/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo`, `objectionary/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo`, `objectionary/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo`, `objectionary/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo`, `objectionary/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo`, `objectionary/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo`, `objectionary/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo`, `objectionary/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo`, `objectionary/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo`, `objectionary/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo`, `objectionary/tests/org/eolang/hamcrest/arrays-matchers-tests.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->